### PR TITLE
Release v1.1.2: UX-Verbesserungen, HTTP-Restriktion & Stabilitätsfixes

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -17,8 +17,8 @@ android {
         applicationId = "dev.dettmer.simplenotes"
         minSdk = 24
         targetSdk = 36
-        versionCode = 3  // 🔥 Bugfix: Spurious Sync Error Notifications + Sync Icon Bug
-        versionName = "1.1.1"  // 🔥 Bugfix: Server-Erreichbarkeits-Check + Notification-Improvements
+        versionCode = 4  // 🔥 v1.1.2: UX Fixes + CancellationException Handling
+        versionName = "1.1.2"  // 🔥 v1.1.2: Better UX + Job Cancellation Fix
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         
@@ -129,6 +129,9 @@ dependencies {
 
     // LocalBroadcastManager für UI Refresh
     implementation("androidx.localbroadcastmanager:localbroadcastmanager:1.1.0")
+
+    // SwipeRefreshLayout für Pull-to-Refresh
+    implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
 
     // Testing (bleiben so)
     testImplementation(libs.junit)

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.SimpleNotes"
-        android:usesCleartextTraffic="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         tools:targetApi="31">
         <activity
             android:name=".MainActivity"

--- a/android/app/src/main/java/dev/dettmer/simplenotes/NoteEditorActivity.kt
+++ b/android/app/src/main/java/dev/dettmer/simplenotes/NoteEditorActivity.kt
@@ -41,7 +41,8 @@ class NoteEditorActivity : AppCompatActivity() {
         setSupportActionBar(toolbar)
         supportActionBar?.apply {
             setDisplayHomeAsUpEnabled(true)
-            setHomeAsUpIndicator(android.R.drawable.ic_menu_close_clear_cancel)
+            // 🔥 v1.1.2: Use default back arrow (Material Design) instead of X icon
+            // Icon is set in XML: app:navigationIcon="?attr/homeAsUpIndicator"
         }
         
         // Find views

--- a/android/app/src/main/java/dev/dettmer/simplenotes/sync/SyncWorker.kt
+++ b/android/app/src/main/java/dev/dettmer/simplenotes/sync/SyncWorker.kt
@@ -8,6 +8,7 @@ import androidx.work.WorkerParameters
 import dev.dettmer.simplenotes.BuildConfig
 import dev.dettmer.simplenotes.utils.Logger
 import dev.dettmer.simplenotes.utils.NotificationHelper
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -52,7 +53,25 @@ class SyncWorker(
             }
             
             if (BuildConfig.DEBUG) {
-                Logger.d(TAG, "📍 Step 2: Checking server reachability (Pre-Check)")
+                Logger.d(TAG, "📍 Step 2: Checking for unsynced changes (Performance Pre-Check)")
+            }
+            
+            // 🔥 v1.1.2: Performance-Optimierung - Skip Sync wenn keine lokalen Änderungen
+            // Spart Batterie + Netzwerk-Traffic + Server-Last
+            if (!syncService.hasUnsyncedChanges()) {
+                Logger.d(TAG, "⏭️ No local changes - skipping sync (performance optimization)")
+                Logger.d(TAG, "   Saves battery, network traffic, and server load")
+                
+                if (BuildConfig.DEBUG) {
+                    Logger.d(TAG, "✅ SyncWorker.doWork() SUCCESS (no changes to sync)")
+                    Logger.d(TAG, "═══════════════════════════════════════")
+                }
+                
+                return@withContext Result.success()
+            }
+            
+            if (BuildConfig.DEBUG) {
+                Logger.d(TAG, "📍 Step 3: Checking server reachability (Pre-Check)")
             }
             
             // ⭐ KRITISCH: Server-Erreichbarkeits-Check VOR Sync
@@ -62,6 +81,9 @@ class SyncWorker(
                 Logger.d(TAG, "⏭️ Server not reachable - skipping sync (no error)")
                 Logger.d(TAG, "   Reason: Server offline/wrong network/network not ready/not configured")
                 Logger.d(TAG, "   This is normal in foreign WiFi or during network initialization")
+                
+                // 🔥 v1.1.2: Check if we should show warning (server unreachable for >24h)
+                checkAndShowSyncWarning(syncService)
                 
                 if (BuildConfig.DEBUG) {
                     Logger.d(TAG, "✅ SyncWorker.doWork() SUCCESS (silent skip)")
@@ -147,6 +169,32 @@ class SyncWorker(
                 }
                 Result.failure()
             }
+        } catch (e: CancellationException) {
+            // ⭐ Job wurde gecancelt - KEIN FEHLER!
+            // Gründe: App-Update, Doze Mode, Battery Optimization, Network Constraint, etc.
+            if (BuildConfig.DEBUG) {
+                Logger.d(TAG, "═══════════════════════════════════════")
+            }
+            Logger.d(TAG, "⏹️ Job was cancelled (normal - update/doze/constraints)")
+            Logger.d(TAG, "   Reason could be: App update, Doze mode, Battery opt, Network disconnect")
+            Logger.d(TAG, "   This is expected Android behavior - not an error!")
+            
+            try {
+                // UI-Refresh trotzdem triggern (falls MainActivity geöffnet)
+                broadcastSyncCompleted(false, 0)
+            } catch (broadcastError: Exception) {
+                Logger.e(TAG, "Failed to broadcast after cancellation", broadcastError)
+            }
+            
+            if (BuildConfig.DEBUG) {
+                Logger.d(TAG, "✅ SyncWorker.doWork() SUCCESS (cancelled, no error)")
+                Logger.d(TAG, "═══════════════════════════════════════")
+            }
+            
+            // ⚠️ WICHTIG: Result.success() zurückgeben!
+            // Cancellation ist KEIN Fehler, WorkManager soll nicht retries machen
+            Result.success()
+            
         } catch (e: Exception) {
             if (BuildConfig.DEBUG) {
                 Logger.d(TAG, "═══════════════════════════════════════")
@@ -188,5 +236,70 @@ class SyncWorker(
         }
         LocalBroadcastManager.getInstance(applicationContext).sendBroadcast(intent)
         Logger.d(TAG, "📡 Broadcast sent: success=$success, count=$count")
+    }
+    
+    /**
+     * Prüft ob Server längere Zeit unreachable und zeigt ggf. Warnung (v1.1.2)
+     * - Nur wenn Auto-Sync aktiviert
+     * - Nur wenn schon mal erfolgreich gesynct
+     * - Nur wenn >24h seit letztem erfolgreichen Sync
+     * - Throttling: Max. 1 Warnung pro 24h
+     */
+    private fun checkAndShowSyncWarning(syncService: WebDavSyncService) {
+        try {
+            val prefs = applicationContext.getSharedPreferences(
+                dev.dettmer.simplenotes.utils.Constants.PREFS_NAME,
+                android.content.Context.MODE_PRIVATE
+            )
+            
+            // Check 1: Auto-Sync aktiviert?
+            val autoSyncEnabled = prefs.getBoolean(
+                dev.dettmer.simplenotes.utils.Constants.KEY_AUTO_SYNC,
+                false
+            )
+            if (!autoSyncEnabled) {
+                Logger.d(TAG, "⏭️ Auto-Sync disabled - no warning needed")
+                return
+            }
+            
+            // Check 2: Schon mal erfolgreich gesynct?
+            val lastSuccessfulSync = syncService.getLastSuccessfulSyncTimestamp()
+            if (lastSuccessfulSync == 0L) {
+                Logger.d(TAG, "⏭️ Never synced successfully - no warning needed")
+                return
+            }
+            
+            // Check 3: >24h seit letztem erfolgreichen Sync?
+            val now = System.currentTimeMillis()
+            val timeSinceLastSync = now - lastSuccessfulSync
+            if (timeSinceLastSync < dev.dettmer.simplenotes.utils.Constants.SYNC_WARNING_THRESHOLD_MS) {
+                Logger.d(TAG, "⏭️ Last successful sync <24h ago - no warning needed")
+                return
+            }
+            
+            // Check 4: Throttling - schon Warnung in letzten 24h gezeigt?
+            val lastWarningShown = prefs.getLong(
+                dev.dettmer.simplenotes.utils.Constants.KEY_LAST_SYNC_WARNING_SHOWN,
+                0L
+            )
+            if (now - lastWarningShown < dev.dettmer.simplenotes.utils.Constants.SYNC_WARNING_THRESHOLD_MS) {
+                Logger.d(TAG, "⏭️ Warning already shown in last 24h - throttling")
+                return
+            }
+            
+            // Zeige Warnung
+            val hoursSinceLastSync = timeSinceLastSync / (1000 * 60 * 60)
+            NotificationHelper.showSyncWarning(applicationContext, hoursSinceLastSync)
+            
+            // Speichere Zeitpunkt der Warnung
+            prefs.edit()
+                .putLong(dev.dettmer.simplenotes.utils.Constants.KEY_LAST_SYNC_WARNING_SHOWN, now)
+                .apply()
+            
+            Logger.d(TAG, "⚠️ Sync warning shown: Server unreachable for ${hoursSinceLastSync}h")
+            
+        } catch (e: Exception) {
+            Logger.e(TAG, "Failed to check/show sync warning", e)
+        }
     }
 }

--- a/android/app/src/main/java/dev/dettmer/simplenotes/utils/Constants.kt
+++ b/android/app/src/main/java/dev/dettmer/simplenotes/utils/Constants.kt
@@ -10,6 +10,11 @@ object Constants {
     const val KEY_AUTO_SYNC = "auto_sync_enabled"
     const val KEY_LAST_SYNC = "last_sync_timestamp"
     
+    // 🔥 v1.1.2: Last Successful Sync Monitoring
+    const val KEY_LAST_SUCCESSFUL_SYNC = "last_successful_sync_time"
+    const val KEY_LAST_SYNC_WARNING_SHOWN = "last_sync_warning_shown_time"
+    const val SYNC_WARNING_THRESHOLD_MS = 24 * 60 * 60 * 1000L  // 24h
+    
     // 🔥 NEU: Sync Interval Configuration
     const val PREF_SYNC_INTERVAL_MINUTES = "sync_interval_minutes"
     const val DEFAULT_SYNC_INTERVAL_MINUTES = 30L

--- a/android/app/src/main/java/dev/dettmer/simplenotes/utils/NotificationHelper.kt
+++ b/android/app/src/main/java/dev/dettmer/simplenotes/utils/NotificationHelper.kt
@@ -288,4 +288,40 @@ object NotificationHelper {
             Logger.d(TAG, "🗑️ Auto-cancelled error notification after 30s timeout")
         }, 30_000)
     }
+    
+    /**
+     * Zeigt Warnung wenn Server längere Zeit nicht erreichbar (v1.1.2)
+     * Throttling: Max. 1 Warnung pro 24h
+     */
+    fun showSyncWarning(context: Context, hoursSinceLastSync: Long) {
+        // PendingIntent für App-Öffnung
+        val intent = Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            0,
+            intent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+        
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.stat_notify_error)
+            .setContentTitle("⚠️ Sync-Warnung")
+            .setContentText("Server seit ${hoursSinceLastSync}h nicht erreichbar")
+            .setStyle(NotificationCompat.BigTextStyle()
+                .bigText("Der WebDAV-Server ist seit ${hoursSinceLastSync} Stunden nicht erreichbar. " +
+                        "Bitte prüfe deine Netzwerkverbindung oder Server-Einstellungen."))
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setCategory(NotificationCompat.CATEGORY_STATUS)
+            .setContentIntent(pendingIntent)
+            .setAutoCancel(true)
+            .build()
+        
+        val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) 
+            as NotificationManager
+        manager.notify(SYNC_NOTIFICATION_ID, notification)
+        
+        Logger.d(TAG, "⚠️ Showed sync warning: Server unreachable for ${hoursSinceLastSync}h")
+    }
 }

--- a/android/app/src/main/java/dev/dettmer/simplenotes/utils/UrlValidator.kt
+++ b/android/app/src/main/java/dev/dettmer/simplenotes/utils/UrlValidator.kt
@@ -1,0 +1,107 @@
+package dev.dettmer.simplenotes.utils
+
+import java.net.URL
+
+/**
+ * URL Validator für Network Security (v1.1.2)
+ * Erlaubt HTTP nur für lokale Netzwerke (RFC 1918 Private IPs)
+ */
+object UrlValidator {
+    
+    /**
+     * Prüft ob eine URL eine lokale/private Adresse ist
+     * Erlaubt:
+     * - 192.168.x.x (Class C private)
+     * - 10.x.x.x (Class A private)
+     * - 172.16.x.x - 172.31.x.x (Class B private)
+     * - 127.x.x.x (Localhost)
+     * - .local domains (mDNS/Bonjour)
+     */
+    fun isLocalUrl(url: String): Boolean {
+        return try {
+            val parsedUrl = URL(url)
+            val host = parsedUrl.host.lowercase()
+            
+            // Check for .local domains (e.g., nas.local)
+            if (host.endsWith(".local")) {
+                return true
+            }
+            
+            // Check for localhost
+            if (host == "localhost" || host == "127.0.0.1") {
+                return true
+            }
+            
+            // Parse IP address if it's numeric
+            val ipPattern = """^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$""".toRegex()
+            val match = ipPattern.find(host)
+            
+            if (match != null) {
+                val octets = match.groupValues.drop(1).map { it.toInt() }
+                
+                // Validate octets are in range 0-255
+                if (octets.any { it > 255 }) {
+                    return false
+                }
+                
+                val (o1, o2, o3, o4) = octets
+                
+                // Check RFC 1918 private IP ranges
+                return when {
+                    // 10.0.0.0/8 (10.0.0.0 - 10.255.255.255)
+                    o1 == 10 -> true
+                    
+                    // 172.16.0.0/12 (172.16.0.0 - 172.31.255.255)
+                    o1 == 172 && o2 in 16..31 -> true
+                    
+                    // 192.168.0.0/16 (192.168.0.0 - 192.168.255.255)
+                    o1 == 192 && o2 == 168 -> true
+                    
+                    // 127.0.0.0/8 (Localhost)
+                    o1 == 127 -> true
+                    
+                    else -> false
+                }
+            }
+            
+            // Not a recognized local address
+            false
+        } catch (e: Exception) {
+            // Invalid URL format
+            false
+        }
+    }
+    
+    /**
+     * Validiert ob HTTP URL erlaubt ist
+     * @return Pair<Boolean, String?> - (isValid, errorMessage)
+     */
+    fun validateHttpUrl(url: String): Pair<Boolean, String?> {
+        return try {
+            val parsedUrl = URL(url)
+            
+            // HTTPS ist immer erlaubt
+            if (parsedUrl.protocol.equals("https", ignoreCase = true)) {
+                return Pair(true, null)
+            }
+            
+            // HTTP nur für lokale URLs erlaubt
+            if (parsedUrl.protocol.equals("http", ignoreCase = true)) {
+                if (isLocalUrl(url)) {
+                    return Pair(true, null)
+                } else {
+                    return Pair(
+                        false,
+                        "HTTP ist nur für lokale Server erlaubt (z.B. 192.168.x.x, 10.x.x.x, nas.local). " +
+                        "Für öffentliche Server verwende bitte HTTPS."
+                    )
+                }
+            }
+            
+            // Anderes Protokoll
+            Pair(false, "Ungültiges Protokoll: ${parsedUrl.protocol}. Bitte verwende HTTP oder HTTPS.")
+        } catch (e: Exception) {
+            Pair(false, "Ungültige URL: ${e.message}")
+        }
+    }
+}

--- a/android/app/src/main/res/layout/activity_editor.xml
+++ b/android/app/src/main/res/layout/activity_editor.xml
@@ -14,7 +14,7 @@
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:elevation="0dp"
-        app:navigationIcon="@android:drawable/ic_menu_close_clear_cancel"
+        app:navigationIcon="?attr/homeAsUpIndicator"
         app:title="@string/edit_note"
         app:titleTextAppearance="@style/TextAppearance.Material3.TitleLarge" />
 

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -24,14 +24,22 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
-    <!-- RecyclerView mit größerem Padding für Material 3 -->
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/recyclerViewNotes"
+    <!-- SwipeRefreshLayout für Pull-to-Refresh (v1.1.2) -->
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipeRefreshLayout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:clipToPadding="false"
-        android:padding="16dp"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <!-- RecyclerView mit größerem Padding für Material 3 -->
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerViewNotes"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:clipToPadding="false"
+            android:padding="16dp" />
+
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
     <!-- Material 3 Empty State Card -->
     <com.google.android.material.card.MaterialCardView

--- a/android/app/src/main/res/layout/activity_settings.xml
+++ b/android/app/src/main/res/layout/activity_settings.xml
@@ -30,17 +30,6 @@
             android:orientation="vertical"
             android:padding="16dp">
 
-            <!-- Auto-Save Status Indicator -->
-            <com.google.android.material.chip.Chip
-                android:id="@+id/chipAutoSaveStatus"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_horizontal"
-                android:layout_marginBottom="12dp"
-                android:visibility="gone"
-                android:textSize="12sp"
-                app:chipIconEnabled="false" />
-
             <!-- Material 3 Card: Server Configuration -->
             <com.google.android.material.card.MaterialCardView
                 android:layout_width="match_parent"
@@ -63,15 +52,65 @@
                         android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
                         android:layout_marginBottom="16dp" />
 
-                    <!-- Server URL with Icon -->
-                    <com.google.android.material.textfield.TextInputLayout
+                    <!-- Protocol Selection -->
+                    <TextView
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:hint="@string/server_url"
+                        android:text="Verbindungstyp"
+                        android:textAppearance="@style/TextAppearance.Material3.LabelLarge"
+                        android:layout_marginBottom="8dp" />
+
+                    <RadioGroup
+                        android:id="@+id/protocolRadioGroup"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:layout_marginBottom="16dp">
+
+                        <com.google.android.material.radiobutton.MaterialRadioButton
+                            android:id="@+id/radioHttp"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="🏠 Intern (HTTP)"
+                            android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+                            android:checked="false" />
+
+                        <com.google.android.material.radiobutton.MaterialRadioButton
+                            android:id="@+id/radioHttps"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="🌐 Extern (HTTPS)"
+                            android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+                            android:checked="true" />
+
+                    </RadioGroup>
+
+                    <!-- Helper Text for Protocol Selection -->
+                    <TextView
+                        android:id="@+id/protocolHintText"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="HTTP nur für lokale Netzwerke (z.B. 192.168.x.x, 10.x.x.x)"
+                        android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+                        android:textColor="?attr/colorOnSurfaceVariant"
+                        android:layout_marginBottom="16dp"
+                        android:paddingStart="4dp"
+                        android:paddingEnd="4dp" />
+
+                    <!-- Server URL with Icon -->
+                    <com.google.android.material.textfield.TextInputLayout
+                        android:id="@+id/textInputLayoutServerUrl"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="Server-Adresse"
                         android:layout_marginBottom="12dp"
                         style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
                         app:startIconDrawable="@android:drawable/ic_menu_compass"
                         app:endIconMode="clear_text"
+                        app:helperText="z.B. http://192.168.0.188:8080/webdav"
+                        app:helperTextEnabled="true"
                         app:boxCornerRadiusTopStart="12dp"
                         app:boxCornerRadiusTopEnd="12dp"
                         app:boxCornerRadiusBottomStart="12dp"
@@ -185,7 +224,7 @@
 
             </com.google.android.material.card.MaterialCardView>
 
-            <!-- Material 3 Card: Auto-Sync Settings -->
+            <!-- Material 3 Card: Synchronisation Settings (Auto-Sync + Interval) -->
             <com.google.android.material.card.MaterialCardView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -230,6 +269,7 @@
                     <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:layout_marginBottom="16dp"
                         android:orientation="horizontal"
                         android:gravity="center_vertical">
 
@@ -247,87 +287,22 @@
 
                     </LinearLayout>
 
-                </LinearLayout>
-
-            </com.google.android.material.card.MaterialCardView>
-
-            <!-- Material 3 Card: Backup & Restore -->
-            <com.google.android.material.card.MaterialCardView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="16dp"
-                style="@style/Widget.Material3.CardView.Elevated"
-                app:cardCornerRadius="16dp">
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:padding="20dp">
-
-                    <!-- Section Header -->
-                    <TextView
+                    <!-- Divider -->
+                    <View
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:text="@string/backup_restore_title"
-                        android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
-                        android:layout_marginBottom="12dp" />
+                        android:layout_height="1dp"
+                        android:layout_marginVertical="16dp"
+                        android:background="?attr/colorOutlineVariant" />
 
-                    <!-- Warning Info Card -->
-                    <com.google.android.material.card.MaterialCardView
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginBottom="16dp"
-                        app:cardBackgroundColor="?attr/colorErrorContainer"
-                        app:cardCornerRadius="12dp"
-                        app:cardElevation="0dp">
-
-                        <TextView
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:padding="16dp"
-                            android:text="@string/backup_restore_warning"
-                            android:textAppearance="@style/TextAppearance.Material3.BodySmall"
-                            android:textColor="?attr/colorOnErrorContainer"
-                            android:lineSpacingMultiplier="1.3" />
-
-                    </com.google.android.material.card.MaterialCardView>
-
-                    <!-- Restore Button -->
-                    <Button
-                        android:id="@+id/buttonRestoreFromServer"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:text="@string/restore_from_server"
-                        style="@style/Widget.Material3.Button.TonalButton" />
-
-                </LinearLayout>
-
-            </com.google.android.material.card.MaterialCardView>
-
-            <!-- Material 3 Card: Sync Interval Configuration -->
-            <com.google.android.material.card.MaterialCardView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="16dp"
-                style="@style/Widget.Material3.CardView.Elevated"
-                app:cardCornerRadius="16dp">
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:padding="20dp">
-
-                    <!-- Section Header -->
+                    <!-- Sync Interval Section -->
                     <TextView
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:text="Sync-Intervall"
-                        android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+                        android:textAppearance="@style/TextAppearance.Material3.LabelLarge"
                         android:layout_marginBottom="12dp" />
 
-                    <!-- Info Card -->
+                    <!-- Interval Info Card -->
                     <com.google.android.material.card.MaterialCardView
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
@@ -407,6 +382,60 @@
                             android:paddingStart="48dp" />
 
                     </RadioGroup>
+
+                </LinearLayout>
+
+            </com.google.android.material.card.MaterialCardView>
+
+            <!-- Material 3 Card: Backup & Restore -->
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                style="@style/Widget.Material3.CardView.Elevated"
+                app:cardCornerRadius="16dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="20dp">
+
+                    <!-- Section Header -->
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/backup_restore_title"
+                        android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+                        android:layout_marginBottom="12dp" />
+
+                    <!-- Warning Info Card -->
+                    <com.google.android.material.card.MaterialCardView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="16dp"
+                        app:cardBackgroundColor="?attr/colorErrorContainer"
+                        app:cardCornerRadius="12dp"
+                        app:cardElevation="0dp">
+
+                        <TextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:padding="16dp"
+                            android:text="@string/backup_restore_warning"
+                            android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+                            android:textColor="?attr/colorOnErrorContainer"
+                            android:lineSpacingMultiplier="1.3" />
+
+                    </com.google.android.material.card.MaterialCardView>
+
+                    <!-- Restore Button -->
+                    <Button
+                        android:id="@+id/buttonRestoreFromServer"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/restore_from_server"
+                        style="@style/Widget.Material3.Button.TonalButton" />
 
                 </LinearLayout>
 

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- Allow HTTP for all connections during development/testing -->
+    <!-- Production validation happens in UrlValidator.kt to restrict HTTP to:
+         - Private IP ranges: 192.168.x.x, 10.x.x.x, 172.16-31.x.x, 127.x.x.x
+         - .local domains (mDNS/Bonjour)
+         
+         This permissive config is necessary because Android's Network Security Config
+         doesn't support IP-based rules, only domain patterns.
+         We handle security through application-level validation instead. -->
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/fastlane/metadata/android/de-DE/changelogs/4.txt
+++ b/fastlane/metadata/android/de-DE/changelogs/4.txt
@@ -1,0 +1,12 @@
+v1.1.2 - UX & Performance
+
+• "Job was cancelled" Fehler behoben
+• Zurück-Pfeil statt X im Editor
+• Pull-to-Refresh für manuellen Sync
+• HTTP/HTTPS Protokoll-Auswahl (Radio Buttons)
+• Inline Fehler-Anzeige (keine Toast-Spam)
+• Settings gruppiert (Auto-Sync & Intervall)
+• Sync nur bei tatsächlichen Änderungen (spart Batterie)
+• 24h Server-Offline Warnung
+• HTTP nur für lokale Netzwerke (RFC 1918 IPs)
+• Auto-Save Benachrichtigungen entfernt

--- a/fastlane/metadata/android/en-US/changelogs/4.txt
+++ b/fastlane/metadata/android/en-US/changelogs/4.txt
@@ -1,0 +1,12 @@
+v1.1.2 - UX & Performance
+
+• Fixed "Job was cancelled" error notifications
+• Back arrow instead of X in editor
+• Pull-to-Refresh for manual sync
+• HTTP/HTTPS protocol selector (radio buttons)
+• Inline error display (no toast spam)
+• Grouped settings (Auto-Sync & Interval)
+• Sync only on actual changes (saves battery)
+• 24h server offline warning
+• HTTP only for local networks (RFC 1918 IPs)
+• Removed auto-save notifications


### PR DESCRIPTION
Dieses Release bringt zahlreiche Verbesserungen für Nutzerfreundlichkeit, Sicherheit und Stabilität:

• "Job was cancelled" Fehler-Benachrichtigungen behoben (WorkManager)
• Zurück-Pfeil statt X im Notiz-Editor (Material Design)
• Pull-to-Refresh für manuellen Sync (Swipe-Geste)
• HTTP/HTTPS Protokoll-Auswahl (Radio Buttons) in den Einstellungen
• HTTP nur noch für lokale Netzwerke (RFC 1918, .local, 127.0.0.1)
• Inline Fehler-Anzeige im URL-Feld (keine Toast-Spam mehr)
• Settings gruppiert (Auto-Sync & Intervall)
• Sync nur bei tatsächlichen Änderungen (Performance-Optimierung)
• 24h Server-Offline Warnung bei längerer Unerreichbarkeit
• Auto-Save Benachrichtigungen entfernt

Alle Änderungen sind F-Droid/ IzzyOnDroid-konform. Version: 1.1.2 (versionCode 4)