### PR TITLE
fix(ci): skip userFraction when rollout is 100%

### DIFF
--- a/.github/workflows/deploy-google-play.yml
+++ b/.github/workflows/deploy-google-play.yml
@@ -68,13 +68,13 @@ jobs:
       - name: Calculate rollout fraction (production only)
         id: rollout
         run: |
-          if [ "${{ inputs.track }}" = "production" ]; then
+          if [ "${{ inputs.track }}" = "production" ] && [ "${{ inputs.rollout_percentage }}" -lt 100 ]; then
             FRACTION=$(echo "scale=4; ${{ inputs.rollout_percentage }} / 100" | bc)
             echo "USER_FRACTION=$FRACTION" >> $GITHUB_OUTPUT
-            echo "Production rollout: ${{ inputs.rollout_percentage }}% → fraction $FRACTION"
+            echo "Production staged rollout: ${{ inputs.rollout_percentage }}% → fraction $FRACTION"
           else
             echo "USER_FRACTION=" >> $GITHUB_OUTPUT
-            echo "Non-production track: no rollout fraction"
+            echo "Full rollout or non-production track: no userFraction"
           fi
 
       - name: Configure Android signing


### PR DESCRIPTION
## Summary
- Fixes the deploy workflow: `userFraction=1.0` is rejected by `r0adkll/upload-google-play` (must be strictly < 1).
- For 100% rollout the parameter is now omitted entirely; only set for staged rollouts (< 100%).

## Root cause
`100 / 100 = 1.0` → action threw `'userFraction' must be between 0 and 1! Got 1`