### PR TITLE
chore(release): bump versionCode to 35 for v2.5.1 re-upload

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "dev.dettmer.simplenotes"
         minSdk = 24
         targetSdk = 36
-        versionCode = 34  // 🆕 v2.5.1 - Note colour sorting
+        versionCode = 35  // 🆕 v2.5.1 - Note colour sorting (code 34 consumed by failed API upload)
         versionName = "2.5.1"  // 🆕 v2.5.1 - Note colour sorting
 
         // APK-Size: nur tatsächlich gepflegte Locales ausliefern. AndroidX/Material/


### PR DESCRIPTION
## Summary
- Increments `versionCode` from 34 → 35 to unblock the v2.5.1 production release upload.
- App content is unchanged; `versionName` stays `2.5.1`.

## Root cause
Two failed GitHub Actions deploy runs consumed version code 34:
1. Run 1: `userFraction=1.0` caused an error after the Play Store edit was committed → code 34 locked.
2. Run 2: "Version code 34 has already been used" confirmed code is permanently consumed.

No draft release was created in Play Console, so the only fix is incrementing the version code.