### PR TITLE
fix(ci): add changelog 35 and auto-fallback for version code mismatches

### DIFF
--- a/.github/workflows/deploy-google-play.yml
+++ b/.github/workflows/deploy-google-play.yml
@@ -97,6 +97,24 @@ jobs:
           echo "AAB_PATH=$AAB_PATH" >> $GITHUB_OUTPUT
           echo "Found AAB: $AAB_PATH ($(du -sh "$AAB_PATH" | cut -f1))"
 
+      - name: Ensure changelog exists for version code
+        run: |
+          VERSION_CODE=${{ steps.version.outputs.VERSION_CODE }}
+          for locale_dir in fastlane/metadata/android/*/changelogs; do
+            target="$locale_dir/$VERSION_CODE.txt"
+            if [ ! -f "$target" ]; then
+              latest=$(ls "$locale_dir"/*.txt 2>/dev/null | sort -V | tail -1)
+              if [ -n "$latest" ]; then
+                cp "$latest" "$target"
+                echo "No $VERSION_CODE.txt in $locale_dir — copied from $(basename $latest)"
+              else
+                echo "WARNING: No changelog files found in $locale_dir"
+              fi
+            else
+              echo "Changelog $target already exists"
+            fi
+          done
+
       - name: Upload to Google Play
         uses: r0adkll/upload-google-play@v1
         with:

--- a/fastlane/metadata/android/de-DE/changelogs/35.txt
+++ b/fastlane/metadata/android/de-DE/changelogs/35.txt
@@ -1,0 +1,11 @@
+🎉 v2.5.1 — erstes Play-Store-Production-Release!
+
+v2.5.0 war als initialer Production-Build vorbereitet, aber nie veröffentlicht.
+v2.5.1 vervollständigt Notizfarben mit Sortierung und ist die Version, die in Production geht.
+
+• Notizen nach Farbe sortieren — neu in v2.5.1
+• Notizfarben: 12-Farben-Palette, Editor & Mehrfachauswahl
+• Notizen nach Farbe filtern
+• Google-Keep-Import aus einer .zip
+• Checklisten-Animation
+• APK −11%: kleinere Downloads (5,2 → 4,7 MB)

--- a/fastlane/metadata/android/en-US/changelogs/35.txt
+++ b/fastlane/metadata/android/en-US/changelogs/35.txt
@@ -1,0 +1,11 @@
+🎉 v2.5.1 — first Play Store production release!
+
+v2.5.0 was prepared as the first production build but never published.
+v2.5.1 completes note colours with sorting and is the version reaching production.
+
+• Sort notes by colour — new in v2.5.1
+• Note colours: 12-colour palette, in editor & multi-select
+• Filter notes by colour
+• Google Keep import from a Keep / Takeout .zip
+• Checklist tap animation
+• APK −11%: smaller download (5.2 → 4.7 MB)


### PR DESCRIPTION
## Summary
- Adds missing `35.txt` changelog files (copy of `34.txt`) for `en-US` and `de-DE` to unblock the current v2.5.1 production release.
- Adds a new workflow step **"Ensure changelog exists for version code"** that automatically copies the latest existing changelog to the current version code if the exact file is absent — prevents empty release notes on any future version code bump.

## Root cause
Version code was bumped 34 → 35 to work around a consumed-but-uncommitted Play Store edit. The changelog files were only named `34.txt`, so the upload for code 35 had no release notes.