### PR TITLE
ci: prepare whatsnew files before upload-google-play action

### DIFF
--- a/.github/workflows/deploy-google-play.yml
+++ b/.github/workflows/deploy-google-play.yml
@@ -101,6 +101,19 @@ jobs:
             fi
           done
 
+      - name: Prepare whatsnew files for upload-google-play action
+        run: |
+          VERSION_CODE=${{ steps.version.outputs.VERSION_CODE }}
+          # r0adkll/upload-google-play expects `whatsnew-<locale>` files directly in
+          # whatsNewDirectory — it does not traverse the Fastlane supply subdirectory
+          # structure (`<locale>/changelogs/<versionCode>.txt`).
+          for changelog in fastlane/metadata/android/*/changelogs/${VERSION_CODE}.txt; do
+            locale=$(echo "$changelog" | sed 's|fastlane/metadata/android/\(.*\)/changelogs/.*|\1|')
+            dest="fastlane/metadata/android/whatsnew-${locale}"
+            cp "$changelog" "$dest"
+            echo "Prepared $dest from $changelog"
+          done
+
       - name: Calculate rollout fraction (production only)
         id: rollout
         run: |


### PR DESCRIPTION
## Problem

`r0adkll/upload-google-play@v1` expects release notes as `whatsnew-<locale>` files directly in `whatsNewDirectory`. It does not traverse the Fastlane supply subdirectory structure (`<locale>/changelogs/<versionCode>.txt`), so the release notes were silently missing from the v2.6.0 Play Store release.

## Fix

Add a prepare step before the upload that copies the versioned changelog (`<versionCode>.txt`) for each locale into `fastlane/metadata/android/whatsnew-en-US` / `whatsnew-de-DE`, which the action then picks up correctly.

## Test plan

- [ ] Verify next release upload includes EN + DE release notes in Play Console