### PR TITLE
remove widget max size restrictions

### DIFF
--- a/android/app/src/main/res/xml/note_widget_info.xml
+++ b/android/app/src/main/res/xml/note_widget_info.xml
@@ -7,8 +7,6 @@
     android:minHeight="110dp"
     android:minResizeWidth="110dp"
     android:minResizeHeight="80dp"
-    android:maxResizeWidth="530dp"
-    android:maxResizeHeight="530dp"
     android:targetCellWidth="3"
     android:targetCellHeight="2"
     android:resizeMode="horizontal|vertical"

--- a/android/app/src/main/res/xml/notes_list_widget_info.xml
+++ b/android/app/src/main/res/xml/notes_list_widget_info.xml
@@ -6,7 +6,6 @@
     android:minHeight="250dp"
     android:minResizeWidth="110dp"
     android:minResizeHeight="180dp"
-    android:maxResizeWidth="530dp"
     android:targetCellWidth="3"
     android:targetCellHeight="3"
     android:resizeMode="horizontal|vertical"


### PR DESCRIPTION
Generally speaking, I see no reason to restrict the max width of this note widget. If the user wants to extend the widget from Timbuktu all the way to Buxtehude, then A) I wonder what the hell they are doing, but B) it is none of my business.

Practically speaking, due to these max width restrictions it is impossible to extend the widget across the whole width of my screen in portrait mode, which annoys me:
<img width="922" height="881" alt="widget" src="https://github.com/user-attachments/assets/9d5e9d76-cf76-4b9c-b38c-46ff2141bb9c" />
